### PR TITLE
Fix README homepage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome! This project hosts simple, interactive machine learning demos and noteb
 
 ## Viewing the Demos
 
-1. Open [the homepage](https://your-github-pages-url) or `index.html` in your browser.
+1. Open [the homepage](https://openai.github.io/ai-ml-demos-workshop) or `index.html` in your browser.
 2. Choose a demo from the list. Each demo lives in the `demos/` folder.
 
 ## Running Notebooks


### PR DESCRIPTION
## Summary
- update README with link to GitHub Pages site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846efd76dec8332bf35fdf807f8e73b