### PR TITLE
Fix outdated demo link text

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             <h2>Demos</h2>
             <nav>
                 <ul>
-                    <li><a href="demos/demo1/">Demo 1: Basic Prediction</a></li>
+                    <li><a href="demos/demo1/">Demo 1: Predict House Prices</a></li>
                 </ul>
             </nav>
         </section>


### PR DESCRIPTION
## Summary
- update the root index page to show the correct demo name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846fa0138dc8332b1b72675a6e074e1