### PR TITLE
Add reset button to demo1

### DIFF
--- a/demos/demo1/index.html
+++ b/demos/demo1/index.html
@@ -19,6 +19,7 @@
     <label for="predict-input">Sq Ft:</label>
     <input type="number" id="predict-input" placeholder="1500" min="600" max="3000">
     <button id="predict-btn">Predict Price</button>
+    <button id="reset-btn">Reset</button>
     <span id="predict-output"></span>
   </div>
 

--- a/demos/demo1/script.js
+++ b/demos/demo1/script.js
@@ -43,6 +43,16 @@ document.getElementById('predict-btn').addEventListener('click', () => {
   }
 });
 
+// Reset button clears all data and predictions
+document.getElementById('reset-btn').addEventListener('click', () => {
+  points = [];
+  coeffs = [];
+  predictionPoint = null;
+  tableBody.innerHTML = '';
+  predictOutput.textContent = '';
+  draw();
+});
+
 function addTableRow(x, y) {
   const tr = document.createElement('tr');
   tr.innerHTML = `<td>${Math.round(x)}</td><td>${y.toFixed(1)}</td>`;


### PR DESCRIPTION
## Summary
- add a reset button to Demo 1's interface
- implement logic in Demo 1 script to clear data and predictions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684703aed370833285e6187a8576daf2