### PR TITLE
Add tick marks on Demo 1 axes

### DIFF
--- a/demos/demo1/script.js
+++ b/demos/demo1/script.js
@@ -136,8 +136,36 @@ function drawAxes() {
   ctx.lineTo(width - margin, height - margin);
   ctx.stroke();
 
+  const numTicks = 5;
   ctx.font = '12px sans-serif';
   ctx.fillStyle = '#000';
+
+  // X-axis ticks and labels
+  for (let i = 0; i <= numTicks; i++) {
+    const x = xMin + (i / numTicks) * (xMax - xMin);
+    const px = dataToCanvasX(x);
+    ctx.beginPath();
+    ctx.moveTo(px, height - margin);
+    ctx.lineTo(px, height - margin + 5);
+    ctx.stroke();
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText(Math.round(x), px, height - margin + 7);
+  }
+
+  // Y-axis ticks and labels
+  for (let i = 0; i <= numTicks; i++) {
+    const y = yMin + (i / numTicks) * (yMax - yMin);
+    const py = dataToCanvasY(y);
+    ctx.beginPath();
+    ctx.moveTo(margin - 5, py);
+    ctx.lineTo(margin, py);
+    ctx.stroke();
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(Math.round(y), margin - 7, py);
+  }
+
   ctx.textAlign = 'center';
   ctx.fillText('Square Footage', width / 2, height - 5);
   ctx.save();


### PR DESCRIPTION
## Summary
- add tick marks and numeric labels on demo1 axes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684703c6498c8332a62c7e79b370d778