### PR TITLE
Fix logistic equation display

### DIFF
--- a/demos/demo2/script.js
+++ b/demos/demo2/script.js
@@ -196,10 +196,13 @@ document.getElementById('reset-btn').addEventListener('click', () => {
 });
 
 document.getElementById('algorithm').addEventListener('change', () => {
+  predictedPoint = null;
+  document.getElementById('prediction').textContent = '';
   updateModel();
   draw();
 });
 
+updateModel();
 draw();
 
 // ----- Models ----- //


### PR DESCRIPTION
## Summary
- clear prediction when switching algorithms
- always update model before drawing so logistic regression equation shows

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68481c6cd1908332b853c5e35efdab73