### PR TITLE
Remove Decision Tree option from demo 2

### DIFF
--- a/demos/demo2/index.html
+++ b/demos/demo2/index.html
@@ -18,7 +18,6 @@
     <select id="algorithm">
       <option value="logistic">Logistic Regression</option>
       <option value="knn">k-NN (k=3)</option>
-      <option value="tree">Decision Tree</option>
     </select>
     <button id="reset-btn">Reset</button>
   </div>


### PR DESCRIPTION
## Summary
- clean up the options for Demo 2

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68481ddaac6083329bb58d5a648645a8